### PR TITLE
created a joblib logger.

### DIFF
--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -64,21 +64,24 @@ class Logger(object):
     """ Base class for logging messages.
     """
 
-    def __init__(self, depth=3):
+    def __init__(self, depth=3, name=None):
         """
             Parameters
             ----------
             depth: int, optional
                 The depth of objects printed.
+            name: str, optional
+                The namespace to log to. If None, defaults to joblib.
         """
         self.depth = depth
+        self._logger = logging.getLogger(name if name else 'joblib')
 
     def warn(self, msg):
-        logging.warning("[%s]: %s" % (self, msg))
+        self._logger.warning("[%s]: %s" % (self, msg))
 
     def debug(self, msg):
         # XXX: This conflicts with the debug flag used in children class
-        logging.debug("[%s]: %s" % (self, msg))
+        self._logger.debug("[%s]: %s" % (self, msg))
 
     def format(self, obj, indent=0):
         """Return the formatted representation of the object."""


### PR DESCRIPTION
using logging.(debug,warning, etc) from within a library is unwise as it appends a stream handler to the root logger. Now you'll be logging to the joblib namespace so that users can specify a logging level via `logging.getLogger('joblib').setLevel(logging.DEBUG)` or whatever they want.

This should also simplify your verbosity arguments if you every want to do that.